### PR TITLE
Making Deployment Changes in server folder

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -11,7 +11,7 @@ app.use(cors());
 
 app.use(express.urlencoded({extended: false}));
 
-const PORT = 5000;
+const PORT = process.env.PORT || 5000;
 
 const length_metrics={
     meter: 1,


### PR DESCRIPTION
-> Hosting services don’t let you decide the port (like 5000) — they assign one dynamically.

-> If you hardcode app.listen(5000), your server will start locally but fail on Render because Render will try to connect on a different port.

-> process.env.PORT is how Render tells your app, “Hey, use this port number I’ve assigned to you".